### PR TITLE
Version bump to trigger new build for glibc 2.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "phoneticmatching",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -707,16 +707,16 @@
       }
     },
     "@mapbox/node-pre-gyp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.6.tgz",
-      "integrity": "sha512-qK1ECws8UxuPqOA8F5LFD90vyVU33W7N3hGfgsOVfrJaRVc8McC3JClTDHpeSbL9CBrOHly/4GsNPAvIgNZE+g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.7.tgz",
+      "integrity": "sha512-PplSvl4pJ5N3BkVjAdDzpPhVUPdC73JgttkR+LnBx2OORC1GCQsBjUeEuipf9uOaAM1SbxcdZFfR3KDTKm2S0A==",
       "requires": {
         "detect-libc": "^1.0.3",
         "https-proxy-agent": "^5.0.0",
         "make-dir": "^3.1.0",
         "node-fetch": "^2.6.5",
         "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
+        "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.11"
@@ -963,9 +963,9 @@
       }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -2129,30 +2129,19 @@
       "dev": true
     },
     "gauge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
-      "integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz",
+      "integrity": "sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==",
       "requires": {
+        "ansi-regex": "^5.0.1",
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
         "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
         "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1 || ^2.0.0",
-        "strip-ansi": "^3.0.1 || ^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        }
       }
     },
     "gensync": {
@@ -2545,11 +2534,6 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -3817,13 +3801,13 @@
       }
     },
     "npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.0.tgz",
+      "integrity": "sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==",
       "requires": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
+        "gauge": "^4.0.0",
         "set-blocking": "^2.0.0"
       }
     },
@@ -3838,11 +3822,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -4995,11 +4974,11 @@
       }
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phoneticmatching",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A text utility to do string comparisons at a phonetic level.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -40,7 +40,7 @@
     "typescript": "^3.9.10"
   },
   "dependencies": {
-    "@mapbox/node-pre-gyp": "^1.0.6",
+    "@mapbox/node-pre-gyp": "^1.0.7",
     "xregexp": "^4.4.1"
   },
   "files": [


### PR DESCRIPTION
Build agent was ubuntu 20, which had glibc 2.31, which had compat issues with older OS's. Switching to ubuntu 18 build agent.

TODO using a azure pipelines/GH actions yaml will make the change more obvious.